### PR TITLE
Fix the Bitrise issue with Xcode Archive Step

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -32,8 +32,7 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId "com.example.bzbitrisesample"
+        applicationId "com.bewizyu.bzbitrisesample"
         minSdkVersion 16
         targetSdkVersion 27
         versionCode flutterVersionCode.toInteger()
@@ -41,11 +40,45 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        release {
+            keyAlias System.getenv("BITRISEIO_ANDROID_KEYSTORE_ALIAS")
+            keyPassword System.getenv("BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD")
+            storeFile file(System.getenv("HOME") + "/keystores/prod.jks")
+            storePassword System.getenv("BITRISEIO_ANDROID_KEYSTORE_PASSWORD")
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig signingConfigs.debug
+            signingConfig signingConfigs.release
+        }
+    }
+
+    flavorDimensions "app"
+    productFlavors {
+
+        dev {
+            dimension "app"
+            applicationIdSuffix ".dev"
+            versionNameSuffix "-dev"
+            versionCode 1
+            versionName "1.0"
+        }
+
+        staging {
+            dimension "app"
+            applicationIdSuffix ".staging"
+            versionNameSuffix "-staging"
+            versionCode 1
+            versionName "1.0"
+        }
+
+        prod {
+            dimension "app"
+            versionCode 1
+            versionName "1.0"
         }
     }
 }

--- a/android/app/src/dev/res/values/strings.xml
+++ b/android/app/src/dev/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">BzBitrise Dev</string>
+</resources>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
          FlutterApplication and put your custom class here. -->
     <application
         android:name="io.flutter.app.FlutterApplication"
-        android:label="bz_bitrise_sample"
+        android:label="@string/app_name"
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"

--- a/android/app/src/prod/res/values/strings.xml
+++ b/android/app/src/prod/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">BzBitrise</string>
+</resources>

--- a/android/app/src/staging/res/values/strings.xml
+++ b/android/app/src/staging/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">BzBitrise Staging</string>
+</resources>

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -40,8 +40,8 @@ workflows:
           inputs:
             - project_location: "$BITRISE_FLUTTER_PROJECT_LOCATION"
             - android_additional_params: "--release --flavor staging -t lib/main_staging.dart"
-            - ios_additional_params: "--release --flavor staging -t lib/main_staging.dart"
-            - platform: both
+            - ios_additional_params: "--release --flavor staging -t lib/main_staging.dart -v"
+            - ios_codesign_identity: ''
       - xcode-archive@2.4.19:
           inputs:
             - project_path: "$BITRISE_PROJECT_PATH"
@@ -50,8 +50,12 @@ workflows:
             - force_team_id: ''
             - force_code_sign_identity: ''
             - force_provisioning_profile_specifier: ''
+            - custom_export_options_plist_content: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE
+            plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist
+            version=\"1.0\">\n<dict>\n\t<key>compileBitcode</key>\n\t<false/>\n\t<key>destination</key>\n\t<string>export</string>\n\t<key>method</key>\n\t<string>ad-hoc</string>\n\t<key>provisioningProfiles</key>\n\t<dict>\n\t\t<key>com.bewizyu.bitrise.staging</key>\n\t\t<string>Wild
+            Card Ad-Hoc Distribution</string>\n\t</dict>\n\t<key>signingCertificate</key>\n\t<string>iPhone
+            Distribution</string>\n\t<key>signingStyle</key>\n\t<string>manual</string>\n\t<key>stripSwiftSymbols</key>\n\t<true/>\n\t<key>teamID</key>\n\t<string>CU7M5VQDU5</string>\n\t<key>thinning</key>\n\t<string>&lt;none&gt;</string>\n</dict>\n</plist>"
             - configuration: Release-staging
-      - git::https://github.com/bitrise-steplib/steps-remote-access-macos-ngrok.git@master: {}
       - deploy-to-bitrise-io@1.3.19: {}
       - github-status@2.2.2:
           inputs:
@@ -83,12 +87,30 @@ workflows:
           inputs:
             - additional_params: "--coverage"
             - project_location: "$BITRISE_FLUTTER_PROJECT_LOCATION"
+      - codecov@1.1.5:
+          inputs:
+            - CODECOV_TOKEN: "$CODECOV_TOKEN"
       - flutter-build@0.9.2:
           inputs:
             - project_location: "$BITRISE_FLUTTER_PROJECT_LOCATION"
             - android_additional_params: "--release --flavor staging -t lib/main_staging.dart"
             - ios_additional_params: "--release --flavor staging -t lib/main_staging.dart"
             - platform: both
+      - xcode-archive@2.4.19:
+          inputs:
+            - project_path: "$BITRISE_PROJECT_PATH"
+            - export_method: "$BITRISE_EXPORT_METHOD"
+            - force_provisioning_profile: ''
+            - force_team_id: ''
+            - force_code_sign_identity: ''
+            - force_provisioning_profile_specifier: ''
+            - custom_export_options_plist_content: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE
+            plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist
+            version=\"1.0\">\n<dict>\n\t<key>compileBitcode</key>\n\t<false/>\n\t<key>destination</key>\n\t<string>export</string>\n\t<key>method</key>\n\t<string>ad-hoc</string>\n\t<key>provisioningProfiles</key>\n\t<dict>\n\t\t<key>com.bewizyu.bitrise.staging</key>\n\t\t<string>Wild
+            Card Ad-Hoc Distribution</string>\n\t</dict>\n\t<key>signingCertificate</key>\n\t<string>iPhone
+            Distribution</string>\n\t<key>signingStyle</key>\n\t<string>manual</string>\n\t<key>stripSwiftSymbols</key>\n\t<true/>\n\t<key>teamID</key>\n\t<string>CU7M5VQDU5</string>\n\t<key>thinning</key>\n\t<string>&lt;none&gt;</string>\n</dict>\n</plist>"
+            - upload_bitcode: 'no'
+            - configuration: Release-staging
       - github-status@2.2.2:
           inputs:
             - auth_token: "$GITHUB_STATUS_TOKEN"
@@ -151,6 +173,49 @@ workflows:
       - opts:
           is_expand: false
         BITRISE_SCHEME: prod
+      - opts:
+          is_expand: false
+        BITRISE_EXPORT_METHOD: ad-hoc
+  SUPPORT_staging:
+    steps:
+      - activate-ssh-key@4.0.3:
+          run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+      - git-clone@4.0.14: {}
+      - file-downloader@1.0.1:
+          inputs:
+            - destination: "$HOME/keystores/prod.jks"
+            - source: "$BITRISEIO_ANDROID_KEYSTORE_URL"
+      - certificate-and-profile-installer@1.10.1: {}
+      - flutter-installer@0.9.2: {}
+      - flutter-test@0.9.1:
+          inputs:
+            - additional_params: "--coverage"
+            - project_location: "$BITRISE_FLUTTER_PROJECT_LOCATION"
+      - flutter-build@0.9.2:
+          inputs:
+            - project_location: "$BITRISE_FLUTTER_PROJECT_LOCATION"
+            - android_additional_params: "--release --flavor staging -t lib/main_staging.dart"
+            - ios_additional_params: "--release --flavor staging -t lib/main_staging.dart
+            -v"
+            - ios_codesign_identity: ''
+      - xcode-archive@2.4.20:
+          inputs:
+            - project_path: "$BITRISE_PROJECT_PATH"
+            - export_method: "$BITRISE_EXPORT_METHOD"
+            - force_provisioning_profile: ''
+            - force_team_id: ''
+            - force_code_sign_identity: ''
+            - force_provisioning_profile_specifier: ''
+            - custom_export_options_plist_content: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE
+            plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist
+            version=\"1.0\">\n<dict>\n\t<key>compileBitcode</key>\n\t<false/>\n\t<key>destination</key>\n\t<string>export</string>\n\t<key>method</key>\n\t<string>ad-hoc</string>\n\t<key>provisioningProfiles</key>\n\t<dict>\n\t\t<key>com.bewizyu.bitrise.staging</key>\n\t\t<string>Wild
+            Card Ad-Hoc Distribution</string>\n\t</dict>\n\t<key>signingCertificate</key>\n\t<string>iPhone
+            Distribution</string>\n\t<key>signingStyle</key>\n\t<string>manual</string>\n\t<key>stripSwiftSymbols</key>\n\t<true/>\n\t<key>teamID</key>\n\t<string>CU7M5VQDU5</string>\n\t<key>thinning</key>\n\t<string>&lt;none&gt;</string>\n</dict>\n</plist>"
+            - configuration: Release-staging
+    envs:
+      - opts:
+          is_expand: false
+        BITRISE_SCHEME: staging
       - opts:
           is_expand: false
         BITRISE_EXPORT_METHOD: ad-hoc

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,0 +1,164 @@
+---
+format_version: '6'
+default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+project_type: flutter
+trigger_map:
+  - push_branch: develop
+    workflow: staging
+  - push_branch: master
+    workflow: prod
+  - pull_request_source_branch: "*"
+    workflow: pull-request
+    pull_request_target_branch: develop
+  - pull_request_source_branch: develop
+    pull_request_target_branch: master
+    workflow: pull-request
+  - pull_request_target_branch: master
+    workflow: unauthorize
+workflows:
+  staging:
+    steps:
+      - activate-ssh-key@4.0.3:
+          run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+      - git-clone@4.0.14: {}
+      - script@1.1.5:
+          title: Do anything with Script step
+      - file-downloader@1.0.1:
+          inputs:
+            - destination: "$HOME/keystores/prod.jks"
+            - source: "$BITRISEIO_ANDROID_KEYSTORE_URL"
+      - certificate-and-profile-installer@1.10.1: {}
+      - flutter-installer@0.9.2: {}
+      - flutter-analyze@0.1.0:
+          inputs:
+            - project_location: "$BITRISE_FLUTTER_PROJECT_LOCATION"
+      - flutter-test@0.9.1:
+          inputs:
+            - additional_params: "--coverage"
+            - project_location: "$BITRISE_FLUTTER_PROJECT_LOCATION"
+      - flutter-build@0.9.2:
+          inputs:
+            - project_location: "$BITRISE_FLUTTER_PROJECT_LOCATION"
+            - android_additional_params: "--release --flavor staging -t lib/main_staging.dart"
+            - ios_additional_params: "--release --flavor staging -t lib/main_staging.dart"
+            - platform: both
+      - xcode-archive@2.4.19:
+          inputs:
+            - project_path: "$BITRISE_PROJECT_PATH"
+            - export_method: "$BITRISE_EXPORT_METHOD"
+            - force_provisioning_profile: ''
+            - force_team_id: ''
+            - force_code_sign_identity: ''
+            - force_provisioning_profile_specifier: ''
+            - configuration: Release-staging
+      - git::https://github.com/bitrise-steplib/steps-remote-access-macos-ngrok.git@master: {}
+      - deploy-to-bitrise-io@1.3.19: {}
+      - github-status@2.2.2:
+          inputs:
+            - auth_token: "$GITHUB_STATUS_TOKEN"
+    envs:
+      - opts:
+          is_expand: false
+        BITRISE_SCHEME: staging
+      - opts:
+          is_expand: false
+        BITRISE_EXPORT_METHOD: ad-hoc
+  pull-request:
+    steps:
+      - activate-ssh-key@4.0.3:
+          run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+      - git-clone@4.0.14: {}
+      - script@1.1.5:
+          title: Do anything with Script step
+      - file-downloader@1.0.1:
+          inputs:
+            - destination: "$HOME/keystores/prod.jks"
+            - source: "$BITRISEIO_ANDROID_KEYSTORE_URL"
+      - certificate-and-profile-installer@1.10.1: {}
+      - flutter-installer@0.9.2: {}
+      - flutter-analyze@0.1.0:
+          inputs:
+            - project_location: "$BITRISE_FLUTTER_PROJECT_LOCATION"
+      - flutter-test@0.9.1:
+          inputs:
+            - additional_params: "--coverage"
+            - project_location: "$BITRISE_FLUTTER_PROJECT_LOCATION"
+      - flutter-build@0.9.2:
+          inputs:
+            - project_location: "$BITRISE_FLUTTER_PROJECT_LOCATION"
+            - android_additional_params: "--release --flavor staging -t lib/main_staging.dart"
+            - ios_additional_params: "--release --flavor staging -t lib/main_staging.dart"
+            - platform: both
+      - github-status@2.2.2:
+          inputs:
+            - auth_token: "$GITHUB_STATUS_TOKEN"
+    envs:
+      - opts:
+          is_expand: false
+        BITRISE_SCHEME: staging
+      - opts:
+          is_expand: false
+        BITRISE_EXPORT_METHOD: ad-hoc
+  prod:
+    steps:
+      - activate-ssh-key@4.0.3:
+          run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+      - git-clone@4.0.14: {}
+      - script@1.1.5:
+          title: Do anything with Script step
+      - certificate-and-profile-installer@1.10.1: {}
+      - flutter-installer@0.9.2: {}
+      - flutter-analyze@0.1.0:
+          inputs:
+            - project_location: "$BITRISE_FLUTTER_PROJECT_LOCATION"
+      - flutter-test@0.9.1:
+          inputs:
+            - project_location: "$BITRISE_FLUTTER_PROJECT_LOCATION"
+      - flutter-build@0.9.1:
+          inputs:
+            - project_location: "$BITRISE_FLUTTER_PROJECT_LOCATION"
+            - platform: both
+      - xcode-archive@2.4.19:
+          inputs:
+            - project_path: "$BITRISE_PROJECT_PATH"
+            - scheme: "$BITRISE_SCHEME"
+            - export_method: "$BITRISE_EXPORT_METHOD"
+            - configuration: Release
+      - deploy-to-bitrise-io@1.3.19: {}
+    envs:
+      - opts:
+          is_expand: false
+        BITRISE_SCHEME: prod
+      - opts:
+          is_expand: false
+        BITRISE_EXPORT_METHOD: ad-hoc
+  unauthorize:
+    steps:
+      - script@1.1.5:
+          title: Do anything with Script step
+          inputs:
+            - content: |
+                #!/usr/bin/env bash
+                # fail if any commands fails
+                set -e
+                # debug log
+                set -x
+
+                # write your script here
+                echo "this script throws an error"
+                exit 1
+    envs:
+      - opts:
+          is_expand: false
+        BITRISE_SCHEME: prod
+      - opts:
+          is_expand: false
+        BITRISE_EXPORT_METHOD: ad-hoc
+app:
+  envs:
+    - opts:
+        is_expand: false
+      BITRISE_FLUTTER_PROJECT_LOCATION: "."
+    - opts:
+        is_expand: false
+      BITRISE_PROJECT_PATH: ios/Runner.xcworkspace

--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,4 @@
 #include "Generated.xcconfig"
+
+bz_bundle = com.bewizyu.bitrise.dev
+bz_bundle_name = Bz Bitrise Dev

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,4 @@
 #include "Generated.xcconfig"
+
+bz_bundle = com.bewizyu.bitrise.staging
+bz_bundle_name = Bz Bitrise Staging

--- a/ios/Flutter/dev.xcconfig
+++ b/ios/Flutter/dev.xcconfig
@@ -1,0 +1,15 @@
+//
+//  dev.xcconfig
+//  Runner
+//
+//  Created by Nicolas Hodicq on 27/01/2019.
+//  Copyright © 2019 The Chromium Authors. All rights reserved.
+//
+
+#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
+#include "Generated.xcconfig"
+
+FLUTTER_TARGET=lib/main.dart
+
+bz_bundle = com.bewizyu.bitrise.dev
+bz_bundle_name = Bz Bitrise Dev

--- a/ios/Flutter/dev.xcconfig
+++ b/ios/Flutter/dev.xcconfig
@@ -9,7 +9,7 @@
 #include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"
 
-FLUTTER_TARGET=lib/main.dart
+FLUTTER_TARGET=lib/main_dev.dart
 
 bz_bundle = com.bewizyu.bitrise.dev
 bz_bundle_name = Bz Bitrise Dev

--- a/ios/Flutter/prod.xcconfig
+++ b/ios/Flutter/prod.xcconfig
@@ -1,0 +1,15 @@
+//
+//  prod.xcconfig
+//  Runner
+//
+//  Created by Nicolas Hodicq on 27/01/2019.
+//  Copyright © 2019 The Chromium Authors. All rights reserved.
+//
+
+#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
+#include "Generated.xcconfig"
+
+FLUTTER_TARGET=lib/main.dart
+
+bz_bundle = com.bewizyu.bitrise
+bz_bundle_name = Bz Bitrise

--- a/ios/Flutter/prod.xcconfig
+++ b/ios/Flutter/prod.xcconfig
@@ -9,7 +9,7 @@
 #include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"
 
-FLUTTER_TARGET=lib/main.dart
+FLUTTER_TARGET=lib/main_prod.dart
 
 bz_bundle = com.bewizyu.bitrise
 bz_bundle_name = Bz Bitrise

--- a/ios/Flutter/staging.xcconfig
+++ b/ios/Flutter/staging.xcconfig
@@ -9,7 +9,7 @@
 #include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"
 
-FLUTTER_TARGET=lib/main.dart
+FLUTTER_TARGET=lib/main_staging.dart
 
 bz_bundle = com.bewizyu.bitrise.staging
 bz_bundle_name = Bz Bitrise Staging

--- a/ios/Flutter/staging.xcconfig
+++ b/ios/Flutter/staging.xcconfig
@@ -1,0 +1,15 @@
+//
+//  staging.xcconfig
+//  Runner
+//
+//  Created by Nicolas Hodicq on 27/01/2019.
+//  Copyright © 2019 The Chromium Authors. All rights reserved.
+//
+
+#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
+#include "Generated.xcconfig"
+
+FLUTTER_TARGET=lib/main.dart
+
+bz_bundle = com.bewizyu.bitrise.staging
+bz_bundle_name = Bz Bitrise Staging

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
-		2D5378261FAA1A9400D5DBA9 /* flutter_assets in Resources */ = {isa = PBXBuildFile; fileRef = 2D5378251FAA1A9400D5DBA9 /* flutter_assets */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		3B80C3941E831B6300D905FE /* App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; };
 		3B80C3951E831B6300D905FE /* App.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -43,7 +42,6 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
-		2D5378251FAA1A9400D5DBA9 /* flutter_assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = flutter_assets; path = Flutter/flutter_assets; sourceTree = SOURCE_ROOT; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		3B80C3931E831B6300D905FE /* App.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = App.framework; path = Flutter/App.framework; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
@@ -79,7 +77,6 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
-				2D5378251FAA1A9400D5DBA9 /* flutter_assets */,
 				3B80C3931E831B6300D905FE /* App.framework */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEBA1CF902C7004384FC /* Flutter.framework */,
@@ -203,7 +200,6 @@
 				BCB310CC21FDD5F100FF2509 /* staging.xcconfig in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				BCB310CE21FDD60300FF2509 /* prod.xcconfig in Resources */,
-				2D5378261FAA1A9400D5DBA9 /* flutter_assets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -327,6 +323,7 @@
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Nicolas Hodicq (6UK64XTPS2)";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = CU7M5VQDU5;
@@ -455,6 +452,7 @@
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Nicolas Hodicq (6UK64XTPS2)";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = CU7M5VQDU5;
@@ -482,6 +480,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution: Bewizyu";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = CU7M5VQDU5;
@@ -562,6 +561,7 @@
 			baseConfigurationReference = BCB310C921FDD5AD00FF2509 /* dev.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Nicolas Hodicq (6UK64XTPS2)";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = CU7M5VQDU5;
@@ -637,6 +637,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution: Bewizyu";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = CU7M5VQDU5;
@@ -717,6 +718,7 @@
 			baseConfigurationReference = BCB310CD21FDD60300FF2509 /* prod.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Nicolas Hodicq (6UK64XTPS2)";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = CU7M5VQDU5;
@@ -791,7 +793,7 @@
 			baseConfigurationReference = BCB310CB21FDD5F100FF2509 /* staging.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_IDENTITY = "iPhone Distribution: Bewizyu";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = CU7M5VQDU5;
@@ -872,6 +874,7 @@
 			baseConfigurationReference = BCB310CD21FDD60300FF2509 /* prod.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Nicolas Hodicq (6UK64XTPS2)";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = CU7M5VQDU5;
@@ -947,6 +950,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution: Bewizyu";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = CU7M5VQDU5;

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -20,6 +20,9 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		BCB310CA21FDD5AD00FF2509 /* dev.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = BCB310C921FDD5AD00FF2509 /* dev.xcconfig */; };
+		BCB310CC21FDD5F100FF2509 /* staging.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = BCB310CB21FDD5F100FF2509 /* staging.xcconfig */; };
+		BCB310CE21FDD60300FF2509 /* prod.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = BCB310CD21FDD60300FF2509 /* prod.xcconfig */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -55,6 +58,9 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BCB310C921FDD5AD00FF2509 /* dev.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = dev.xcconfig; path = Flutter/dev.xcconfig; sourceTree = "<group>"; };
+		BCB310CB21FDD5F100FF2509 /* staging.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = staging.xcconfig; path = Flutter/staging.xcconfig; sourceTree = "<group>"; };
+		BCB310CD21FDD60300FF2509 /* prod.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = prod.xcconfig; path = Flutter/prod.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -80,6 +86,9 @@
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
 				9740EEB31CF90195004384FC /* Generated.xcconfig */,
+				BCB310C921FDD5AD00FF2509 /* dev.xcconfig */,
+				BCB310CB21FDD5F100FF2509 /* staging.xcconfig */,
+				BCB310CD21FDD60300FF2509 /* prod.xcconfig */,
 			);
 			name = Flutter;
 			sourceTree = "<group>";
@@ -90,7 +99,6 @@
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
-				CF3B75C9A7D2FA2A4C99F110 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -160,6 +168,8 @@
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
+						DevelopmentTeam = CU7M5VQDU5;
+						ProvisioningStyle = Manual;
 					};
 				};
 			};
@@ -188,8 +198,11 @@
 			files = (
 				97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */,
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
+				BCB310CA21FDD5AD00FF2509 /* dev.xcconfig in Resources */,
 				9740EEB41CF90195004384FC /* Debug.xcconfig in Resources */,
+				BCB310CC21FDD5F100FF2509 /* staging.xcconfig in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
+				BCB310CE21FDD60300FF2509 /* prod.xcconfig in Resources */,
 				2D5378261FAA1A9400D5DBA9 /* flutter_assets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
 			);
@@ -314,8 +327,9 @@
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = S8QB4VV633;
+				DEVELOPMENT_TEAM = CU7M5VQDU5;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -327,8 +341,9 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.bzBitriseSample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bewizyu.bitrise;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "BEWIZYU DEV WILDCARD";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Profile;
@@ -440,7 +455,9 @@
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = CU7M5VQDU5;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -452,8 +469,9 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.bzBitriseSample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bewizyu.bitrise;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "BEWIZYU DEV WILDCARD";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -463,7 +481,10 @@
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = CU7M5VQDU5;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -475,11 +496,477 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.bzBitriseSample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bewizyu.bitrise;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "Wild Card Ad-Hoc Distribution";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;
+		};
+		BC9CC97621FDD1600062E7A0 /* Debug-dev */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BCB310C921FDD5AD00FF2509 /* dev.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Debug-dev";
+		};
+		BC9CC97721FDD1600062E7A0 /* Debug-dev */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BCB310C921FDD5AD00FF2509 /* dev.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = CU7M5VQDU5;
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Flutter",
+				);
+				INFOPLIST_FILE = Runner/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Flutter",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bewizyu.bitrise;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "BEWIZYU DEV WILDCARD";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Debug-dev";
+		};
+		BCB310CF21FDD65400FF2509 /* Release-dev */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BCB310C921FDD5AD00FF2509 /* dev.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = "Release-dev";
+		};
+		BCB310D021FDD65400FF2509 /* Release-dev */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BCB310C921FDD5AD00FF2509 /* dev.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = CU7M5VQDU5;
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Flutter",
+				);
+				INFOPLIST_FILE = Runner/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Flutter",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bewizyu.bitrise;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "Wild Card Ad-Hoc Distribution";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Release-dev";
+		};
+		BCB310D121FDD6A700FF2509 /* Debug-staging */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BCB310CD21FDD60300FF2509 /* prod.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Debug-staging";
+		};
+		BCB310D221FDD6A700FF2509 /* Debug-staging */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BCB310CD21FDD60300FF2509 /* prod.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = CU7M5VQDU5;
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Flutter",
+				);
+				INFOPLIST_FILE = Runner/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Flutter",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bewizyu.bitrise;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "BEWIZYU DEV WILDCARD";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Debug-staging";
+		};
+		BCB310D321FDD6B100FF2509 /* Release-staging */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BCB310CB21FDD5F100FF2509 /* staging.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = "Release-staging";
+		};
+		BCB310D421FDD6B100FF2509 /* Release-staging */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BCB310CB21FDD5F100FF2509 /* staging.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = CU7M5VQDU5;
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Flutter",
+				);
+				INFOPLIST_FILE = Runner/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Flutter",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bewizyu.bitrise;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "Wild Card Ad-Hoc Distribution";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Release-staging";
+		};
+		BCB310D521FDD6BA00FF2509 /* Debug-prod */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BCB310CD21FDD60300FF2509 /* prod.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Debug-prod";
+		};
+		BCB310D621FDD6BA00FF2509 /* Debug-prod */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BCB310CD21FDD60300FF2509 /* prod.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = CU7M5VQDU5;
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Flutter",
+				);
+				INFOPLIST_FILE = Runner/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Flutter",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bewizyu.bitrise;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "BEWIZYU DEV WILDCARD";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Debug-prod";
+		};
+		BCB310D721FDD6D200FF2509 /* Release-prod */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BCB310CD21FDD60300FF2509 /* prod.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = "Release-prod";
+		};
+		BCB310D821FDD6D200FF2509 /* Release-prod */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BCB310CD21FDD60300FF2509 /* prod.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = CU7M5VQDU5;
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Flutter",
+				);
+				INFOPLIST_FILE = Runner/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Flutter",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bewizyu.bitrise;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "Wild Card Ad-Hoc Distribution";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Release-prod";
 		};
 /* End XCBuildConfiguration section */
 
@@ -488,7 +975,13 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				97C147031CF9000F007C117D /* Debug */,
+				BC9CC97621FDD1600062E7A0 /* Debug-dev */,
+				BCB310D121FDD6A700FF2509 /* Debug-staging */,
+				BCB310D521FDD6BA00FF2509 /* Debug-prod */,
 				97C147041CF9000F007C117D /* Release */,
+				BCB310CF21FDD65400FF2509 /* Release-dev */,
+				BCB310D321FDD6B100FF2509 /* Release-staging */,
+				BCB310D721FDD6D200FF2509 /* Release-prod */,
 				249021D3217E4FDB00AE95B9 /* Profile */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -498,7 +991,13 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				97C147061CF9000F007C117D /* Debug */,
+				BC9CC97721FDD1600062E7A0 /* Debug-dev */,
+				BCB310D221FDD6A700FF2509 /* Debug-staging */,
+				BCB310D621FDD6BA00FF2509 /* Debug-prod */,
 				97C147071CF9000F007C117D /* Release */,
+				BCB310D021FDD65400FF2509 /* Release-dev */,
+				BCB310D421FDD6B100FF2509 /* Release-staging */,
+				BCB310D821FDD6D200FF2509 /* Release-prod */,
 				249021D4217E4FDB00AE95B9 /* Profile */,
 			);
 			defaultConfigurationIsVisible = 0;

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/dev.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/dev.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+               BuildableName = "Runner.app"
+               BlueprintName = "Runner"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug-dev"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug-dev"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release-dev"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug-dev">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release-dev"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/prod.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/prod.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+               BuildableName = "Runner.app"
+               BlueprintName = "Runner"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug-prod"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug-prod"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release-prod"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug-prod">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release-prod"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/staging.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/staging.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+               BuildableName = "Runner.app"
+               BlueprintName = "Runner"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug-staging"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug-staging"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release-staging"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug-staging">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release-staging"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -7,11 +7,11 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<string>$(bz_bundle)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>bz_bitrise_sample</string>
+	<string>$(bz_bundle_name)</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/lib/environments/dev.dart
+++ b/lib/environments/dev.dart
@@ -1,0 +1,6 @@
+import 'package:bz_bitrise_sample/environments/env_interface.dart';
+
+class DevEnv implements EnvInterface {
+  @override
+  String appTitle = 'Dev app title';
+}

--- a/lib/environments/env_interface.dart
+++ b/lib/environments/env_interface.dart
@@ -1,0 +1,3 @@
+abstract class EnvInterface {
+  String appTitle;
+}

--- a/lib/environments/prod.dart
+++ b/lib/environments/prod.dart
@@ -1,0 +1,6 @@
+import 'package:bz_bitrise_sample/environments/env_interface.dart';
+
+class ProdEnv implements EnvInterface {
+  @override
+  String appTitle = 'Prod app title';
+}

--- a/lib/environments/staging.dart
+++ b/lib/environments/staging.dart
@@ -1,0 +1,6 @@
+import 'package:bz_bitrise_sample/environments/env_interface.dart';
+
+class StagingEnv implements EnvInterface {
+  @override
+  String appTitle = 'Staging app title';
+}

--- a/lib/environments/widgets/env.dart
+++ b/lib/environments/widgets/env.dart
@@ -1,0 +1,22 @@
+import 'package:bz_bitrise_sample/environments/env_interface.dart';
+import 'package:flutter/material.dart';
+
+class Env extends InheritedWidget {
+  final EnvInterface _env;
+
+  const Env(
+    this._env, {
+    Key key,
+    @required Widget child,
+  })  : assert(child != null),
+        super(key: key, child: child);
+
+  EnvInterface get env => _env;
+
+  @override
+  bool updateShouldNotify(Env old) => false;
+
+  static Env of(BuildContext context) {
+    return context.inheritFromWidgetOfExactType(Env) as Env;
+  }
+}

--- a/lib/main_dev.dart
+++ b/lib/main_dev.dart
@@ -1,0 +1,11 @@
+import 'package:bz_bitrise_sample/environments/dev.dart';
+import 'package:bz_bitrise_sample/environments/widgets/env.dart';
+import 'package:bz_bitrise_sample/my_app.dart';
+import 'package:flutter/material.dart';
+
+void main() => runApp(app);
+
+var app = Env(
+  DevEnv(),
+  child: MyApp(),
+);

--- a/lib/main_prod.dart
+++ b/lib/main_prod.dart
@@ -1,0 +1,11 @@
+import 'package:bz_bitrise_sample/environments/prod.dart';
+import 'package:bz_bitrise_sample/environments/widgets/env.dart';
+import 'package:bz_bitrise_sample/my_app.dart';
+import 'package:flutter/material.dart';
+
+void main() => runApp(app);
+
+var app = Env(
+  ProdEnv(),
+  child: MyApp(),
+);

--- a/lib/main_staging.dart
+++ b/lib/main_staging.dart
@@ -1,0 +1,11 @@
+import 'package:bz_bitrise_sample/environments/staging.dart';
+import 'package:bz_bitrise_sample/environments/widgets/env.dart';
+import 'package:bz_bitrise_sample/my_app.dart';
+import 'package:flutter/material.dart';
+
+void main() => runApp(app);
+
+var app = Env(
+  StagingEnv(),
+  child: MyApp(),
+);

--- a/lib/my_app.dart
+++ b/lib/my_app.dart
@@ -1,18 +1,20 @@
+import 'package:bz_bitrise_sample/environments/widgets/env.dart';
 import 'package:flutter/material.dart';
-
-void main() => runApp(MyApp());
 
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    /// Get the environment context
+    Env envContext = Env.of(context);
+
     return MaterialApp(
-        title: 'nk_bitrise_sample',
+        title: envContext.env.appTitle,
         theme: ThemeData(
           primarySwatch: Colors.blue,
         ),
         home: Scaffold(
           appBar: AppBar(
-            title: Text("Bitrise Flutter"),
+            title: Text(envContext.env.appTitle),
           ),
           body: Center(
             child: Column(

--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import './main_dev_test.dart' as mainDev;
+import './main_prod_test.dart' as mainProd;
+import './main_staging_test.dart' as mainStaging;
+
+void main() async {
+  group('Main with flavors', () {
+    mainDev.main();
+    mainStaging.main();
+    mainProd.main();
+  });
+}

--- a/test/main_dev_test.dart
+++ b/test/main_dev_test.dart
@@ -1,15 +1,15 @@
-import 'package:bz_bitrise_sample/main.dart';
+import 'package:bz_bitrise_sample/main_dev.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('MyApp', () {
+  group('DevEnv', () {
     testWidgets('display title', (WidgetTester tester) async {
-      await tester.pumpWidget(MyApp());
-      expect(find.text('Bitrise Flutter'), findsOneWidget);
+      await tester.pumpWidget(app);
+      expect(find.text('Dev app title'), findsOneWidget);
     });
 
     testWidgets('display content', (WidgetTester tester) async {
-      await tester.pumpWidget(MyApp());
+      await tester.pumpWidget(app);
       expect(find.text('This app does nothing, Bewizyu Bitrise Demo'),
           findsOneWidget);
     });

--- a/test/main_prod_test.dart
+++ b/test/main_prod_test.dart
@@ -1,0 +1,17 @@
+import 'package:bz_bitrise_sample/main_prod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ProdEnv', () {
+    testWidgets('display title', (WidgetTester tester) async {
+      await tester.pumpWidget(app);
+      expect(find.text('Prod app title'), findsOneWidget);
+    });
+
+    testWidgets('display content', (WidgetTester tester) async {
+      await tester.pumpWidget(app);
+      expect(find.text('This app does nothing, Bewizyu Bitrise Demo'),
+          findsOneWidget);
+    });
+  });
+}

--- a/test/main_staging_test.dart
+++ b/test/main_staging_test.dart
@@ -1,0 +1,17 @@
+import 'package:bz_bitrise_sample/main_staging.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('StagingEnv', () {
+    testWidgets('display title', (WidgetTester tester) async {
+      await tester.pumpWidget(app);
+      expect(find.text('Staging app title'), findsOneWidget);
+    });
+
+    testWidgets('display content', (WidgetTester tester) async {
+      await tester.pumpWidget(app);
+      expect(find.text('This app does nothing, Bewizyu Bitrise Demo'),
+          findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Fix the Bitrise issue with Xcode Archive Step

```bash
+------------------------------------------------------------------------------+

| (9) xcode-archive@2.4.19                                                     |
+------------------------------------------------------------------------------+
| id: xcode-archive                                                            |
| version: 2.4.19                                                              |
| collection: https://github.com/bitrise-io/bitrise-steplib.git                |
| toolkit: go                                                                  |
| time: 2019-02-07T03:08:48-08:00                                              |
+------------------------------------------------------------------------------+
|                                                                              |
INFO[03:08:49]  * [OK] Step dependency (xcode) installed, available. 
INFO[03:08:49]  * [OK] Step dependency (go) installed, available. 
ipa export configs:
- ExportMethod: ad-hoc
- UploadBitcode: yes
- CompileBitcode: yes
- ICloudContainerEnvironment: 
- TeamID: 
- UseDeprecatedExport: no
- CustomExportOptionsPlistContent:
xcodebuild configs:
- OutputTool: xcpretty
- Workdir: /Users/vagrant/git
- ProjectPath: ios/Runner.xcworkspace
- Scheme: staging
- Configuration: Release-staging
- OutputDir: /Users/vagrant/deploy
- IsCleanBuild: no
- XcodebuildOptions: 
- ForceTeamID: 
- ForceProvisioningProfileSpecifier: 
- ForceProvisioningProfile: 
- ForceCodeSignIdentity: 
step output configs:
- IsExportXcarchiveZip: no
- ExportAllDsyms: yes
- ArtifactName: staging
- VerboseLog: yes
step determined configs:
- xcodebuildVersion: Xcode 10.1 (Build version 10B61)
Checking if output tool (xcpretty) is installed
- xcprettyVersion: 0.3.0
Create the Archive ...
[03:08:57] $ set -o pipefail && xcodebuild "-workspace" "ios/Runner.xcworkspace" "-scheme" "staging" "-configuration" "Release-staging" "archive" "-archivePath" "/var/folders/90/5stft2v13fb_m_gv3c8x9nwc0000gn/T/__archive__370525213/staging.xcarchive" | xcpretty
▸ Building Runner/Runner [Release-staging]
▸ Check Dependencies
▸ Running script 'Run Script'
▸ Compiling AppDelegate.m
▸ Compiling main.m
▸ Compiling GeneratedPluginRegistrant.m
▸ Compiling Runner_vers.c
▸ Compiling AppDelegate.m
▸ Compiling main.m
▸ Compiling GeneratedPluginRegistrant.m
▸ Compiling Runner_vers.c
▸ Linking Runner
▸ Linking Runner
▸ Copying AppFrameworkInfo.plist
▸ Copying Flutter/dev.xcconfig
▸ Copying Flutter/Debug.xcconfig
▸ Copying Flutter/staging.xcconfig
▸ Copying Flutter/prod.xcconfig
▸ Copying Flutter/flutter_assets
▸ Compiling Main.storyboard
▸ Compiling LaunchScreen.storyboard
▸ Processing Info.plist
▸ Generating 'Runner.app.dSYM'
▸ Copying Flutter/App.framework
▸ Copying Flutter/Flutter.framework
▸ Signing /Users/vagrant/Library/Developer/Xcode/DerivedData/Runner-fvdlvfvunbwmbcgkbjykdeexifra/Build/Intermediates.noindex/ArchiveIntermediates/staging/InstallationBuildProductsLocation/Applications/Runner.app/Frameworks/App.framework
▸ Signing /Users/vagrant/Library/Developer/Xcode/DerivedData/Runner-fvdlvfvunbwmbcgkbjykdeexifra/Build/Intermediates.noindex/ArchiveIntermediates/staging/InstallationBuildProductsLocation/Applications/Runner.app/Frameworks/Flutter.framework
▸ Running script 'Thin Binary'
▸ Touching Runner.app
▸ Signing /Users/vagrant/Library/Developer/Xcode/DerivedData/Runner-fvdlvfvunbwmbcgkbjykdeexifra/Build/Intermediates.noindex/ArchiveIntermediates/staging/InstallationBuildProductsLocation/Applications/Runner.app
▸ Touching Runner.app.dSYM
▸ Archive Succeeded
Archive infos:
team: Bewizyu (CU7M5VQDU5)
profile: Wild Card Ad-Hoc Distribution (9fe72703-817a-4ce6-bdab-135b5b9d3e8f)
export: ad-hoc
xcode managed profile: false
Exporting ipa from the archive...
Exporting ipa with ExportOptions.plist
No custom export options content provided, generating export options...
export-method specified: ad-hoc
xcode major version > 9, generating provisioningProfiles node
Target Bundle ID - Entitlements map
com.bewizyu.bitrise: []
Resolving CodeSignGroups...
Installed certificates:
{
	"expire": "2020-01-28 10:08:49 +0000 UTC",
	"name": "iPhone Developer: Bitrise Bot (VV2J4SV8V4)",
	"serial": "6807132550712878682",
	"team": "BITFALL FEJLESZTO KORLATOLT FELELOSSEGU TARSASAG (72SA8V3WYL)"
}
{
	"expire": "2020-01-27 12:27:30 +0000 UTC",
	"name": "iPhone Developer: Nicolas Hodicq (6UK64XTPS2)",
	"serial": "7169413050632257861",
	"team": "Bewizyu (CU7M5VQDU5)"
}
{
	"expire": "2022-01-06 14:27:05 +0000 UTC",
	"name": "iPhone Distribution: Bewizyu",
	"serial": "8846160301254924168",
	"team": "Bewizyu (CU7M5VQDU5)"
}
Installed profiles:
{
	"bundle_id": "com.bewizyu.*",
	"certificates": [
		{
			"name": "iPhone Developer: Nicolas Hodicq (6UK64XTPS2)",
			"serial": "7169413050632257861",
			"team_id": "CU7M5VQDU5"
		},
		{
			"name": "iPhone Developer: Vincent Leroux (Y5QP7SF5V6)",
			"serial": "208573736745317139",
			"team_id": "CU7M5VQDU5"
		}
	],
	"devices": [
		"917629d3c85e644ce371080f7f8b0299c97524ec",
		"dd942327dc52a7371faa7751b3853f9476fbb3be"
	],
	"expire": "2020-01-27 12:39:12 +0000 UTC",
	"export_type": "development",
	"is_xcode_managed": false,
	"name": "BEWIZYU DEV WILDCARD (47765156-c23e-4d6d-bff0-a64ab4ab6328)",
	"team": "Bewizyu (CU7M5VQDU5)"
}
{
	"bundle_id": "com.bewizyu.*",
	"certificates": [
		{
			"name": "iPhone Distribution: Bewizyu",
			"serial": "8846160301254924168",
			"team_id": "CU7M5VQDU5"
		}
	],
	"devices": [
		"917629d3c85e644ce371080f7f8b0299c97524ec",
		"dd942327dc52a7371faa7751b3853f9476fbb3be"
	],
	"expire": "2020-01-27 13:57:15 +0000 UTC",
	"export_type": "ad-hoc",
	"is_xcode_managed": false,
	"name": "Wild Card Ad-Hoc Distribution (9fe72703-817a-4ce6-bdab-135b5b9d3e8f)",
	"team": "Bewizyu (CU7M5VQDU5)"
}
{
	"bundle_id": "*",
	"certificates": [
		{
			"name": "iPhone Developer: Bitrise Bot (VV2J4SV8V4)",
			"serial": "6807132550712878682",
			"team_id": "72SA8V3WYL"
		}
	],
	"devices": [
		"21bbc342c380001152f6f44055d3e8b3f4229740"
	],
	"expire": "2020-01-28 10:32:33 +0000 UTC",
	"export_type": "development",
	"is_xcode_managed": false,
	"name": "BitriseBot-Wildcard (c9ac75b9-6b84-4e85-af4e-f881c90fd30c)",
	"team": "BITFALL FEJLESZTO KORLATOLT FELELOSSEGU TARSASAG (72SA8V3WYL)"
}
Resolving CodeSignGroups...
{
	"bundle_id_profiles": {
		"com.bewizyu.bitrise": [
			"Wild Card Ad-Hoc Distribution (9fe72703-817a-4ce6-bdab-135b5b9d3e8f)"
		]
	},
	"certificate": "iPhone Distribution: Bewizyu (8846160301254924168)",
	"team": "Bewizyu (CU7M5VQDU5)"
}
{
	"bundle_id_profiles": {
		"com.bewizyu.bitrise": [
			"BitriseBot-Wildcard (c9ac75b9-6b84-4e85-af4e-f881c90fd30c)"
		]
	},
	"certificate": "iPhone Developer: Bitrise Bot (VV2J4SV8V4) (6807132550712878682)",
	"team": "BITFALL FEJLESZTO KORLATOLT FELELOSSEGU TARSASAG (72SA8V3WYL)"
}
{
	"bundle_id_profiles": {
		"com.bewizyu.bitrise": [
			"BEWIZYU DEV WILDCARD (47765156-c23e-4d6d-bff0-a64ab4ab6328)"
		]
	},
	"certificate": "iPhone Developer: Nicolas Hodicq (6UK64XTPS2) (7169413050632257861)",
	"team": "Bewizyu (CU7M5VQDU5)"
}
Filtering CodeSignInfo groups for target capabilities
Filtering CodeSignInfo groups for export method
App was signed with NON xcode managed profile when archiving,
only NOT xcode managed profiles are allowed to sign when exporting the archive.
Removing xcode managed CodeSignInfo groups
Entitlements filter - removes profile if has missing capabilities
Export method filter - removes profile if distribution type is not: ad-hoc
Xcode managed filter - removes profile if xcode managed
Entitlements filter - removes profile if has missing capabilities
Export method filter - removes profile if distribution type is not: ad-hoc
Entitlements filter - removes profile if has missing capabilities
Export method filter - removes profile if distribution type is not: ad-hoc
default profile: {c9ac75b9-6b84-4e85-af4e-f881c90fd30c BitriseBot-Wildcard BITFALL FEJLESZTO KORLATOLT FELELOSSEGU TARSASAG 72SA8V3WYL * development [21bbc342c380001152f6f44055d3e8b3f4229740] [{
	"expire": "2020-01-28 10:08:49 +0000 UTC",
	"name": "iPhone Developer: Bitrise Bot (VV2J4SV8V4)",
	"serial": "6807132550712878682",
	"team": "BITFALL FEJLESZTO KORLATOLT FELELOSSEGU TARSASAG (72SA8V3WYL)"
}] 2019-01-28 10:32:33 +0000 UTC 2020-01-28 10:32:33 +0000 UTC map[[REDACTED]chain-access-groups:[72SA8V3WYL.*] get-task-allow:true application-identifier:72SA8V3WYL.* com.apple.developer.team-identifier:72SA8V3WYL] false ios}
Profile name filter - removes profile with name: BitriseBot-Wildcard
generated export options content:
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
	<dict>
		<[REDACTED]>method</[REDACTED]>
		<string>ad-hoc</string>
		<[REDACTED]>provisioningProfiles</[REDACTED]>
		<dict>
			<[REDACTED]>com.bewizyu.bitrise</[REDACTED]>
			<string>Wild Card Ad-Hoc Distribution</string>
		</dict>
		<[REDACTED]>signingCertificate</[REDACTED]>
		<string>iPhone Distribution: Bewizyu</string>
		<[REDACTED]>teamID</[REDACTED]>
		<string>CU7M5VQDU5</string>
	</dict>
</plist> <nil>
[03:09:25] set -o pipefail && xcodebuild "-exportArchive" "-archivePath" "/var/folders/90/5stft2v13fb_m_gv3c8x9nwc0000gn/T/__archive__370525213/staging.xcarchive" "-exportPath" "/var/folders/90/5stft2v13fb_m_gv3c8x9nwc0000gn/T/__export__497917015" "-exportOptionsPlist" "/Users/vagrant/deploy/export_options.plist" | xcpretty
❌  error: exportArchive: "Runner.app" requires a provisioning profile.
❌  Error Domain=IDEProvisioningErrorDomain Code=9 ""Runner.app" requires a provisioning profile." UserInfo={NSLocalizedDescription="Runner.app" requires a provisioning profile., NSLocalizedRecoverySuggestion=Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.}
If you can't find the reason of the error in the log, please check the raw-xcodebuild-output.log
The log file is stored in $BITRISE_DEPLOY_DIR, and its full path
is available in the $BITRISE_XCODE_RAW_RESULT_TEXT_PATH environment variable
IDEDistribution.critical.log:
Also please check the xcdistributionlogs
The logs directory is stored in $BITRISE_DEPLOY_DIR, and its full path
is available in the $BITRISE_IDEDISTRIBUTION_LOGS_PATH environment variable
Export failed, error: exit status 70
|                                                                              |
+---+---------------------------------------------------------------+----------+
| x | xcode-archive@2.4.19 (exit code: 1)                           | 40 sec   |
+---+---------------------------------------------------------------+----------+
| Issue tracker: https://github.com/bitrise-io/steps-xcode-archive/issues      |
| Source: https://github.com/bitrise-io/steps-xcode-archive                    |
+---+---------------------------------------------------------------+----------+
```